### PR TITLE
use consistent pinned docs pull

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -18,6 +18,7 @@ env:
   JUPYTER_VERSION: "2025-04-14"
   # If you want to include custom documentation, create a fork of the repo below and link the forked repo here
   NOMAD_DOCS_REPO: https://github.com/FAIRmat-NFDI/nomad-docs.git
+  NOMAD_DOCS_REPO_REF: "main"
   # If you want to skip the tests for some plugins, add them to the list below
   PLUGIN_TESTS_PLUGINS_TO_SKIP: |
     workflowparsers
@@ -162,6 +163,34 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository }}${{ matrix.image_suffix }}
 
+      - name: Derive NOMAD docs ref from locked nomad-lab
+        id: docs_ref
+        run: |
+          set -euo pipefail
+          NOMAD_LAB_VERSION=$(
+            sed -n '/name = "nomad-lab"/{n;s/version = "\(.*\)"/\1/p;q;}' uv.lock
+          )
+          if [ -z "${NOMAD_LAB_VERSION}" ]; then
+            echo "ref=${NOMAD_DOCS_REPO_REF}" >> "$GITHUB_OUTPUT"
+            echo "package=nomad-docs" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Strip local/dev suffixes, e.g. 1.4.2.dev43+g123 -> 1.4.2
+          BASE_VERSION="${NOMAD_LAB_VERSION%%+*}"
+          BASE_VERSION="${BASE_VERSION%%.dev*}"
+          DOCS_TAG="v${BASE_VERSION}"
+
+          if git ls-remote --exit-code --tags "${NOMAD_DOCS_REPO}" "refs/tags/${DOCS_TAG}" >/dev/null 2>&1; then
+            echo "ref=${DOCS_TAG}" >> "$GITHUB_OUTPUT"
+            # Prefer pinning docs python package to the same docs git ref.
+            echo "package=git+${NOMAD_DOCS_REPO}@${DOCS_TAG}" >> "$GITHUB_OUTPUT"
+          else
+            echo "nomad-docs tag ${DOCS_TAG} not found in ${NOMAD_DOCS_REPO}; falling back to unpinned nomad-docs package." >&2
+            echo "ref=${NOMAD_DOCS_REPO_REF}" >> "$GITHUB_OUTPUT"
+            echo "package=nomad-docs" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
@@ -170,6 +199,8 @@ jobs:
             UV_VERSION=${{ env.UV_VERSION }}
             PYTHON_VERSION=${{ env.PYTHON_VERSION }}
             NOMAD_DOCS_REPO=${{ env.NOMAD_DOCS_REPO }}
+            NOMAD_DOCS_REPO_REF=${{ steps.docs_ref.outputs.ref }}
+            NOMAD_DOCS_PACKAGE=${{ steps.docs_ref.outputs.package }}
             JUPYTER_VERSION=${{ env.JUPYTER_VERSION }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -52,7 +52,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref || github.ref_name }}
+          repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
           submodules: true
 
       - name: Install uv
@@ -69,7 +70,7 @@ jobs:
 
       # Commits any changes made to the lockfile
       - name: Commit lock file changes
-        if: github.ref_type != 'tag'
+        if: github.event_name != 'pull_request' && github.ref_type != 'tag'
         run: |
           git config --global user.name github-actions
           git config --global user.email github-actions@github.com
@@ -93,7 +94,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref || github.ref_name }}
+          repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
           submodules: true
 
       - name: Install uv
@@ -147,7 +149,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref || github.ref_name }}
+          repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
           submodules: true
 
       - uses: docker/setup-buildx-action@v3
@@ -230,7 +233,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref || github.ref_name }}
+          repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
           submodules: true
 
       - uses: docker/login-action@v3

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -18,7 +18,7 @@ env:
   JUPYTER_VERSION: "2025-04-14"
   # If you want to include custom documentation, create a fork of the repo below and link the forked repo here
   NOMAD_DOCS_REPO: https://github.com/FAIRmat-NFDI/nomad-docs.git
-  NOMAD_DOCS_REPO_REF: "main"
+  NOMAD_DOCS_REPO_REF: ""
   # If you want to skip the tests for some plugins, add them to the list below
   PLUGIN_TESTS_PLUGINS_TO_SKIP: |
     workflowparsers
@@ -166,34 +166,6 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository }}${{ matrix.image_suffix }}
 
-      - name: Derive NOMAD docs ref from locked nomad-lab
-        id: docs_ref
-        run: |
-          set -euo pipefail
-          NOMAD_LAB_VERSION=$(
-            sed -n '/name = "nomad-lab"/{n;s/version = "\(.*\)"/\1/p;q;}' uv.lock
-          )
-          if [ -z "${NOMAD_LAB_VERSION}" ]; then
-            echo "ref=${NOMAD_DOCS_REPO_REF}" >> "$GITHUB_OUTPUT"
-            echo "package=nomad-docs" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          # Strip local/dev suffixes, e.g. 1.4.2.dev43+g123 -> 1.4.2
-          BASE_VERSION="${NOMAD_LAB_VERSION%%+*}"
-          BASE_VERSION="${BASE_VERSION%%.dev*}"
-          DOCS_TAG="v${BASE_VERSION}"
-
-          if git ls-remote --exit-code --tags "${NOMAD_DOCS_REPO}" "refs/tags/${DOCS_TAG}" >/dev/null 2>&1; then
-            echo "ref=${DOCS_TAG}" >> "$GITHUB_OUTPUT"
-            # Prefer pinning docs python package to the same docs git ref.
-            echo "package=git+${NOMAD_DOCS_REPO}@${DOCS_TAG}" >> "$GITHUB_OUTPUT"
-          else
-            echo "nomad-docs tag ${DOCS_TAG} not found in ${NOMAD_DOCS_REPO}; falling back to unpinned nomad-docs package." >&2
-            echo "ref=${NOMAD_DOCS_REPO_REF}" >> "$GITHUB_OUTPUT"
-            echo "package=nomad-docs" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
@@ -202,8 +174,7 @@ jobs:
             UV_VERSION=${{ env.UV_VERSION }}
             PYTHON_VERSION=${{ env.PYTHON_VERSION }}
             NOMAD_DOCS_REPO=${{ env.NOMAD_DOCS_REPO }}
-            NOMAD_DOCS_REPO_REF=${{ steps.docs_ref.outputs.ref }}
-            NOMAD_DOCS_PACKAGE=${{ steps.docs_ref.outputs.package }}
+            NOMAD_DOCS_REPO_REF=${{ env.NOMAD_DOCS_REPO_REF }}
             JUPYTER_VERSION=${{ env.JUPYTER_VERSION }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -179,7 +179,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           target: ${{ matrix.target }}
-          push: ${{ github.event_name != 'pull_request' }}
+          push: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
@@ -195,7 +195,7 @@ jobs:
   # Job 4: Run example upload tests and entrypoint tests
   run_tests:
     name: Run example upload tests and entrypoint tests
-    if: github.event_name != 'pull_request'
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     needs: build
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -179,7 +179,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           target: ${{ matrix.target }}
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
@@ -195,6 +195,7 @@ jobs:
   # Job 4: Run example upload tests and entrypoint tests
   run_tests:
     name: Run example upload tests and entrypoint tests
+    if: github.event_name != 'pull_request'
     needs: build
     runs-on: ubuntu-latest
     env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -97,19 +97,40 @@ FROM builder AS docs
 WORKDIR /app
 
 ARG NOMAD_DOCS_REPO="https://github.com/FAIRmat-NFDI/nomad-docs.git"
-ARG NOMAD_DOCS_REPO_REF="main"
-ARG NOMAD_DOCS_PACKAGE="nomad-docs"
+ARG NOMAD_DOCS_REPO_REF=""
 
-RUN set -ex && \
-    echo "Cloning from: ${NOMAD_DOCS_REPO}; branch: ${NOMAD_DOCS_REPO_REF}" && \
-    git clone --branch "${NOMAD_DOCS_REPO_REF}" "${NOMAD_DOCS_REPO}" docs
-
+# Clones the documentation repository, checks out the version matching nomad-lab
+# (unless a specific NOMAD_DOCS_REPO_REF is provided), installs it, and builds the documentation.
 RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=uv.lock,target=uv.lock \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
-    uv run --with "${NOMAD_DOCS_PACKAGE}" --directory docs mkdocs build \
-    && mkdir -p built_docs \
-    && cp -r docs/site/* built_docs
+    set -ex && \
+    # Clone the documentation repository \
+    echo "Cloning from: ${NOMAD_DOCS_REPO}" && \
+    git clone "${NOMAD_DOCS_REPO}" docs_repo && cd docs_repo && \
+    # Determine which version to build \
+    if [ -n "${NOMAD_DOCS_REPO_REF}" ]; then \
+        # Use explicitly provided ref \
+        echo "Checking out provided ref: ${NOMAD_DOCS_REPO_REF}"; \
+        git checkout "${NOMAD_DOCS_REPO_REF}"; \
+    else \
+        # Match documentation version to nomad-lab version \
+        NOMAD_VERSION=$(uv tree --package nomad-lab | grep "^nomad-lab v" | sed 's/^nomad-lab //'); \
+        echo "Detected nomad-lab version: ${NOMAD_VERSION}"; \
+        if git rev-parse --verify "refs/tags/${NOMAD_VERSION}" >/dev/null 2>&1; then \
+            echo "Tag ${NOMAD_VERSION} found. Checking out."; \
+            git checkout "${NOMAD_VERSION}"; \
+        else \
+            echo "Tag ${NOMAD_VERSION} not found. Checking out main branch."; \
+            git checkout main; \
+        fi; \
+    fi && \
+    # Install and build documentation \
+    uv pip install . && \
+    PYTHONPATH=src uv run --no-sync mkdocs build && \
+    # Move built site to final destination \
+    mkdir -p /app/built_docs && \
+    cp -r site/* /app/built_docs
 
 FROM builder AS gpu_action_builder
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -97,15 +97,17 @@ FROM builder AS docs
 WORKDIR /app
 
 ARG NOMAD_DOCS_REPO="https://github.com/FAIRmat-NFDI/nomad-docs.git"
+ARG NOMAD_DOCS_REPO_REF="main"
+ARG NOMAD_DOCS_PACKAGE="nomad-docs"
 
 RUN set -ex && \
-    echo "Cloning from: $NOMAD_DOCS_REPO" && \
-    git clone "$NOMAD_DOCS_REPO" docs
+    echo "Cloning from: ${NOMAD_DOCS_REPO}; branch: ${NOMAD_DOCS_REPO_REF}" && \
+    git clone --branch "${NOMAD_DOCS_REPO_REF}" "${NOMAD_DOCS_REPO}" docs
 
 RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=uv.lock,target=uv.lock \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
-    uv run --with nomad-docs --directory docs mkdocs build \
+    uv run --with "${NOMAD_DOCS_PACKAGE}" --directory docs mkdocs build \
     && mkdir -p built_docs \
     && cp -r docs/site/* built_docs
 


### PR DESCRIPTION
@pdi-sina this is in response to the message you sent Sebastian about pulling the wrong nomad-lab version upon image build, even though you have nomad-lab pinned to 1.4.1. I think this may be due to a dependency issue when you pull the nomad-docs, as I had similar issues with some other images. 

Here is a proposed fix which I have check on a couple other Oasis systems. I am also in contact with the NOMAD developers in case they suggest a different solution. If so, I will put in an update, but for now you can run the workflow and if it passes you can merge and try to redeploy. Let me know if you have further issues. 

docker-publish.yml docs linking approach:

- Derive BASE_VERSION from locked nomad-lab.
- Try to verify docs tag exists 
- If found, use 
- If not found fallback to unpinned version